### PR TITLE
Add WebSocket Proxying to nginx sample config

### DIFF
--- a/pages/02.install/06.reverse-proxy/01.nginx-example/default.md
+++ b/pages/02.install/06.reverse-proxy/01.nginx-example/default.md
@@ -18,7 +18,16 @@ server{
          # Proxy to Kavita running locally on port 5000 using ssl
          proxy_pass https://127.0.0.1:5000 ;
      }
-        server_name kavita.example.com;
+     
+    location /hubs {
+        proxy_pass http://127.0.0.1:5000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+    }
+    
+    server_name kavita.example.com;
 
     listen 443 ssl; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot


### PR DESCRIPTION
With this additional option, the scan progress is also shown when Kavita is accessed through an nginx reverse proxy.