### PR TITLE
Add WebSocket Proxying to nginx sample config

### DIFF
--- a/pages/02.install/06.reverse-proxy/01.nginx-example/default.md
+++ b/pages/02.install/06.reverse-proxy/01.nginx-example/default.md
@@ -15,10 +15,16 @@ server{
          proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for; aio threads;
          proxy_set_header        X-Forwarded-Proto $scheme;
 
+         # Headers to proxy websocket connections
+         proxy_http_version 1.1;
+         proxy_set_header Upgrade $http_upgrade;
+         proxy_set_header Connection "Upgrade"; 
+
          # Proxy to Kavita running locally on port 5000 using ssl
          proxy_pass https://127.0.0.1:5000 ;
-     }
-        server_name kavita.example.com;
+    }
+     
+    server_name kavita.example.com;
 
     listen 443 ssl; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot


### PR DESCRIPTION
Sorry I deleted my previous PR. Anyways, I implemented the WebSocket support directly under the root location.  

With this additional option, the scan progress is also shown when Kavita is accessed through an nginx reverse proxy.  

https://nginx.org/en/docs/http/websocket.html