### PR TITLE
Add PikaPods managed hosting option

### DIFF
--- a/pages/02.install/11.managed-hosting/default.en.md
+++ b/pages/02.install/11.managed-hosting/default.en.md
@@ -1,0 +1,15 @@
+---
+title: 'Managed Hosting'
+---
+
+## Managed Hosting
+
+If you don't administer your own server, you can also use a managed hosting offering to run Kavita:
+
+### PikaPods
+
+Based on the official Docker image. EU and US data regions available. Daily backups and weekly updates. 20% of app revenues are contributed back to the project via our Open Collective.
+
+Start free with $5 free welcome credit:
+
+[![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=kavita)

--- a/pages/02.install/default.md
+++ b/pages/02.install/default.md
@@ -12,6 +12,7 @@ These are the guides for the supported systems
 * [macOS](https://wiki.kavitareader.com/install/macos)
 * Various NAS devices like [Unraid](https://wiki.kavitareader.com/install/unraid), [TrueNAS Scale](https://wiki.kavitareader.com/en/install/truenas-scale), or [OpenMediaVault](https://www.openmediavault.org/)
 * [Synology](https://wiki.kavitareader.com/en/install/synology)
+* [Managed Hosting](https://wiki.kavitareader.com/install/managed-hosting) - without administering own server
 
 >>> There's an article that explains how to restore a backup if needed in [this page](backup.en.md) 
 


### PR DESCRIPTION
As discussed on Discord. Adds page for managed hosting options and PikaPods.

[Preview](https://github.com/m3nu/Wiki/blob/add-pikapods/pages/02.install/11.managed-hosting/default.en.md)