### PR TITLE
Update documentation for setup of apache2 reverse proxy in front of Kavita

### DIFF
--- a/pages/03.install/10.access-kavita-from-network/reverse-proxy/04.apache2-example/default.md
+++ b/pages/03.install/10.access-kavita-from-network/reverse-proxy/04.apache2-example/default.md
@@ -2,11 +2,13 @@
 title: 'Apache2 Example'
 ---
 
-### Apache2 Example
+These examples assume that Kavita is running on host 192.168.0.152 port 5000, and that apache is being used for SSL termination (Kavita is running http). If you intend for apache to serve http alone, rather than https with a redirect for http, you will need to make your virtualhost definitions use port 80, and remove all of the config lines starting with SSL. If upstream is running serving https, you'll need to modify the proxy lines to reference https and the websocket lines to reference wss instead of ws.
+
+### Basic Apache2 Example
 ```
 <IfModule mod_ssl.c>
 <VirtualHost *:443>
-        ServerName kavita.example.com
+        ServerName example.com
         SSLEngine on
         SSLProxyEngine on
         SSLProxyCheckPeerCN off
@@ -18,36 +20,36 @@ title: 'Apache2 Example'
         SSLCertificateChainFile /etc/letsencrypt/intermediate.pem
         ErrorLog ${APACHE_LOG_DIR}/proxy-error.log
         CustomLog ${APACHE_LOG_DIR}/proxy-access.log combined
-        ProxyPass / http://192.168.1.17:5000/
-        ProxyPassReverse / http://192.168.1.17:5000/
+        ProxyPass / http://192.168.0.152:5000/
+        ProxyPassReverse / http://192.168.0.152:5000/
         ProxyPreserveHost On
         ProxyRequests Off
         RewriteEngine On
-        RewriteCond %{HTTP:UPGRADE} ^WebSocket$ [NC]
-        RewriteCond %{HTTP:CONNECTION} ^Upgrade$ [NC]
-        RewriteRule .* wss://192.168.1.217%{REQUEST_URI} [P]
+        RewriteCond %{HTTP:UPGRADE} ^.*WebSocket.*$ [NC]
+        RewriteCond %{HTTP:CONNECTION} ^.*Upgrade.*$ [NC]
+        RewriteRule .* ws://192.168.0.152:5000%{REQUEST_URI} [P]
         RequestHeader set X-Forwarded-Proto "https"
         RequestHeader set X-Forwarded-Port "443"
         RequestHeader set X-Forwarded-For "%{REMOTE_ADDR}e"
 </VirtualHost>
 </IfModule>
 ```
-In this example 192.168.1.17 is the IP address of the Kavita host.
 
 ### Kavita on a new domain/subdomain
 ```
 <VirtualHost *:80>
 # Since, We are using HTTPS, we redirect all HTTP queries to HTTPS.
-# If you want to use HTTP only, then copy the 4 lines that start with Proxy below and paste them here. Also delete/comment out the redirect line below.       
-        ServerName subdomain.domain.com
+# If you want to use HTTP only, then copy the 4 lines that start with Proxy and 3 lines that start with Rewrite below and paste them here. Also delete/comment out the redirect line, and the entire second virtualhost block.
+        ServerName subdomain.example.com
 # ServerName is the name of the domain/subdomain Kavita is being hosted on.
-        Redirect permanent / https://subdomain.domain.com
+        Redirect permanent / https://subdomain.example.com
 </VirtualHost>
 <VirtualHost *:443>
-    ServerName subdomain.domain.com
+    ServerName subdomain.example.com
     ErrorLog ${APACHE_LOG_DIR}/error.log
     CustomLog ${APACHE_LOG_DIR}/access.log combined
 # This specifies the location where your logs are stored. By default, it is stored in a combined log with all other apache configs.
+
     SSLEngine on
     SSLProxyEngine on
     SSLProxyVerify none
@@ -55,20 +57,24 @@ In this example 192.168.1.17 is the IP address of the Kavita host.
     SSLProxyCheckPeerName off
     SSLProxyCheckPeerExpire off
 # All of these are for the SSL and Reverse Proxy. If you need more info, refer here https://httpd.apache.org/docs/2.4/mod/mod_ssl.html
-    
+
+    SSLCertificateFile /etc/univention/letsencrypt/signed_chain.crt
+    SSLCertificateKeyFile /etc/letsencrypt/domain.key
+    SSLCACertificateFile /etc/ssl/ucsCA/CAcert.pem
+    SSLCertificateChainFile /etc/letsencrypt/intermediate.pem
+# Since we are using SSL, we will have to give locations for all the SSL Certificates. Note - Apache must be able to go into the directories you mention in the path above. (This means that the directory needs to have o+x or have apache as user or group of the directory.)
+
     ProxyPreserveHost On
     ProxyRequests Off
     ProxyPass / http://192.168.0.152:5000/
     ProxyPassReverse / http://192.168.0.152:5000/
+    RewriteCond %{HTTP:UPGRADE} ^.*WebSocket.*$ [NC]
+    RewriteCond %{HTTP:CONNECTION} ^.*Upgrade.*$ [NC]
+    RewriteRule .* ws://192.168.0.152:5000%{REQUEST_URI} [P]
 # For more info on Apache Proxy Config, see here https://httpd.apache.org/docs/2.4/mod/mod_proxy.html
-# For HTTP config, the above 4 lines need to be copied.
 # These lines tell Apache to send all requests to the root of the domain (/) to (http://192.168.0.152:5000/)
 # The example assumes that Kavita is hosted on the IP 192.168.0.152. Use localhost if Kavita is on the same machine as Apache.
     
-    SSLCertificateFile      /path/to/certificate/
-    SSLCertificateKeyFile   /path/to/key/
-    SSLCACertificateFile    /path/to/CA/Certificate
-# Since we are using SSL, we will have to give locations for all the SSL Certificates. Note - Apache must be able to go into the directories you mention in the path above. (This means that the directory needs to have o+x or have apache as user or group of the directory.)
 </VirtualHost>
 ```
 
@@ -78,7 +84,7 @@ When using this, make sure you set the Base URL field in Kavita Settings.
 ```
 <VirtualHost *:80>
 # Since, We are using HTTPS, we redirect all HTTP queries to HTTPS.
-# If you want to use HTTP only, then copy the 6 lines below and paste them here
+# If you want to use HTTP only, then copy the 9 lines below and paste them here
       <...Your existing config lines go here...>
 </VirtualHost>
 <VirtualHost *:443>
@@ -86,10 +92,13 @@ When using this, make sure you set the Base URL field in Kavita Settings.
 ProxyPreserveHost On
 ProxyRequests Off
 <Location /kavita>
-        ProxyPass http://localhost:5000
-        ProxyPassReverse http://localhost:5000
+        ProxyPass http://192.168.0.152:5000
+        ProxyPassReverse http://192.168.0.152:5000
+        RewriteCond %{HTTP:UPGRADE} ^.*WebSocket.*$ [NC]
+        RewriteCond %{HTTP:CONNECTION} ^.*Upgrade.*$ [NC]
+        RewriteRule .* ws://192.168.0.152:5000%{REQUEST_URI} [P]
 </Location>
-# For HTTP config, the above 6 lines need to be copied and pasted.
+# For HTTP config, the above 9 lines need to be copied and pasted.
 # These lines tell Apache to send all requests from the subpath of the domain (/kavita) to (http://192.168.0.152:5000/)
 # The example assumes that Kavita is hosted on the IP 192.168.0.152. Use localhost if Kavita is on the same machine as Apache.
     <... Your existing config lines go here...>


### PR DESCRIPTION
Summary of changes:

- Made domain names and IP addresses consistent
- Reorganized vhost contents to be more consistent and logically grouped
- Add missing ports for some proxy lines
- Add missing Rewrite lines for websockets
- Fixed Rewrite lines to match
- Clarified how http/https and ws/wss work.

Motivation:

I encountered problems with Firefox using the following header for ws connections:

Connection: keep-alive, Upgrade

The original documentation specified ^Upgrade$, which doesn't match, and the connection was failing.