### PR TITLE
Clarify that Paperback progress syncing is one way

### DIFF
--- a/pages/05.faq/03.external-readers/default.en.md
+++ b/pages/05.faq/03.external-readers/default.en.md
@@ -29,9 +29,10 @@ What you find below is not an exhaustive list, but rather what has been tested t
 | Panels    |  ✓   |    ✓    |  ✗   |       ✓       |      ✗       |
 | Yomu      |  ✓   |    ✗    |  ✓   |       ✗       |      ✗       |
 | [Paperback](https://wiki.kavitareader.com/en/guides/misc/paperback) | ✗  |     ✗    |  ✗    |        ✓**       |     ✓       |
-| [Aidoku](https://wiki.kavitareader.com/en/guides/misc/aidoku) | ✗  |     ✗    |  ✗    |        ✓**       |     ✓       |
+| [Aidoku](https://wiki.kavitareader.com/en/guides/misc/aidoku) | ✗  |     ✗    |  ✗    |        ✓**†       |     ✓       |
 <br/>* Does not use opds. However, for ease of setup the same link retrieved from this setting is used<br/>
 ** Progress syncing is done per chapter, not per page
+† Progress syncing is one way from Paperback to Kavita, does not support two way sync
 
 ## Other
 | Name      | Opds | Opds-PS | Epub | Progress Sync | API |


### PR DESCRIPTION
Clarification from extension author:
>yes, ur right. it is also stated in "https://wiki.kavitareader.com/en/faq/external-readers".
 https://discord.com/channels/821879810934439936/932273034277048381/1176144296156606514

although I could not find the statement, so adding it here